### PR TITLE
Fix bug where two identical edges are added in the case of a self loop; Fix Traverse

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -41,7 +41,9 @@ func (g *ItemGraph) AddEdge(n1, n2 *Node) {
 		g.edges = make(map[Node][]*Node)
 	}
 	g.edges[*n1] = append(g.edges[*n1], n2)
-	g.edges[*n2] = append(g.edges[*n2], n1)
+	if *n1 != *n2 {
+		g.edges[*n2] = append(g.edges[*n2], n1)
+	}
 	g.lock.Unlock()
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -70,20 +70,20 @@ func (g *ItemGraph) Traverse(f func(*Node)) {
 	q.New()
 	n := g.nodes[0]
 	q.Enqueue(*n)
-	visited := make(map[*Node]bool)
+	visited := make(map[Node]bool)
 	for {
 		if q.IsEmpty() {
 			break
 		}
 		node := q.Dequeue()
-		visited[node] = true
+		visited[*node] = true
 		near := g.edges[*node]
 
 		for i := 0; i < len(near); i++ {
 			j := near[i]
-			if !visited[j] {
+			if !visited[*j] {
 				q.Enqueue(*j)
-				visited[j] = true
+				visited[*j] = true
 			}
 		}
 		if f != nil {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -27,6 +27,7 @@ func fillGraph() {
 	g.AddEdge(&nC, &nE)
 	g.AddEdge(&nE, &nF)
 	g.AddEdge(&nD, &nA)
+	g.AddEdge(&nD, &nD)
 }
 
 func TestAdd(t *testing.T) {


### PR DESCRIPTION
- Don't add the second edge if `n1` and `n2` are equal
- Fix `Traverse` visited

Before:

```
=== RUN   TestAdd
A -> B C D
B -> A E
C -> A E
D -> A D D
E -> B C F
F -> E

--- PASS: TestAdd (0.00s)
=== RUN   TestTraverse
A
B
C
D
A
E
F
--- PASS: TestTraverse (0.00s)
PASS
ok  	github.com/nicholaslam/datastructures/graph	0.677s
```

After:

```
=== RUN   TestAdd
A -> B C D
B -> A E
C -> A E
D -> A D
E -> B C F
F -> E

--- PASS: TestAdd (0.00s)
=== RUN   TestTraverse
A
B
C
D
E
F
--- PASS: TestTraverse (0.00s)
PASS
ok  	github.com/nicholaslam/datastructures/graph	0.022s
```